### PR TITLE
fix:修复success_killed表中create_time为空的问题

### DIFF
--- a/src/main/sql/schema.sql
+++ b/src/main/sql/schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE success_killed(
   `seckill_id` BIGINT NOT NULL COMMENT '秒杀商品ID',
   `user_phone` BIGINT NOT NULL COMMENT '用户手机号',
   `state` TINYINT NOT NULL DEFAULT -1 COMMENT '状态标识:-1:无效 0:成功 1:已付款 2:已发货',
-  `create_time` TIMESTAMP NOT NULL COMMENT '创建时间',
+  `create_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
   PRIMARY KEY(seckill_id,user_phone),/*联合主键*/
   KEY idx_create_time(create_time)
 )ENGINE=INNODB DEFAULT CHARSET=utf8 COMMENT='秒杀成功明细表';


### PR DESCRIPTION
（MySQL version:8.0.19）在创建success_killed表的schema.sql中，要设置create_time自动更新，因为insertSuccessKilled()没有插入create_time，create_time为默认值00-00-00 00:00:00。不然在测试queryByIdWithSeckill()时程序会报错：Caused by: com.mysql.cj.exceptions.DataReadException: Zero date value prohibited。